### PR TITLE
Old style exceptions --> new style for Python 3

### DIFF
--- a/CVE-2019-1040.py
+++ b/CVE-2019-1040.py
@@ -77,7 +77,7 @@ class PrinterBug(object):
             tmp  = self.lookup(rpctransport, remote_host)
             if tmp:
                 return True
-        except Exception, e:
+        except Exception as e:
             if logging.getLogger().level == logging.DEBUG:
                 import traceback
                 traceback.print_exc()
@@ -91,7 +91,7 @@ class PrinterBug(object):
         logging.critical('Bind OK')
         try:
             resp = rprn.hRpcOpenPrinter(dce, '\\\\%s\x00' % host)
-        except Exception, e:
+        except Exception as e:
             if str(e).find('Broken pipe') >= 0:
                 # The connection timed-out. Let's try to bring it back next round
                 logging.error('Connection failed - skipping host!')
@@ -157,7 +157,7 @@ def startServers(passargs):
             try:
                 while exp.isAlive():
                     pass
-            except KeyboardInterrupt, e:
+            except KeyboardInterrupt as e:
                 logging.info("Shutting down...")
                 for thread in serverThreads:
                     thread.server.shutdown()
@@ -200,7 +200,7 @@ def gethash(passargs):
                          domain, execmethod, dcuser,hashes)
     try:
         check = dumper.dump()
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/comm/secretsdump.py
+++ b/comm/secretsdump.py
@@ -81,7 +81,7 @@ class DumpSecrets:
                 try:
                     try:
                         self.connect()
-                    except Exception, e:
+                    except Exception as e:
                         if os.getenv('KRB5CCNAME') is not None and self.__doKerberos is True:
                             # SMBConnection failed. That might be because there was no way to log into the
                             # target system. We just have a last resort. Hope we have tickets cached and that they
@@ -98,7 +98,7 @@ class DumpSecrets:
                         bootKey             = self.__remoteOps.getBootKey()
                         # Let's check whether target system stores LM Hashes
                         self.__noLMHash = self.__remoteOps.checkNoLMHashPolicy()
-                except Exception, e:
+                except Exception as e:
                     self.__canProcessSAMLSA = False
                     if str(e).find('STATUS_USER_SESSION_DELETED') and os.getenv('KRB5CCNAME') is not None \
                         and self.__doKerberos is True:
@@ -128,7 +128,7 @@ class DumpSecrets:
                 if self.__NTDSHashes:
                     self.cleanup()
                     return True
-            except Exception, e:
+            except Exception as e:
                 if logging.getLogger().level == logging.DEBUG:
                     import traceback
                     traceback.print_exc()
@@ -140,7 +140,7 @@ class DumpSecrets:
                         os.unlink(resumeFile)
                 self.cleanup()
                 return False
-        except (Exception, KeyboardInterrupt), e:
+        except (Exception, KeyboardInterrupt) as e:
             try:
                 self.cleanup()
             except:


### PR DESCRIPTION
Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.